### PR TITLE
v2.1: Honest repositioning - from 'research' to 'practitioner's guide'

### DIFF
--- a/Contribution Guide.md
+++ b/Contribution Guide.md
@@ -1,6 +1,6 @@
 # 🤝 Contributing to Pineapple Lab OS Docs
 
-Thanks for your interest in contributing to the Pineapple Lab OS Docs. This is an open, research-driven space exploring advanced prompt engineering and agent design. Whether you want to tweak a typo, add a prompt, or propose new evaluation logic — you're welcome here.
+Thanks for your interest in contributing to the Pineapple Lab OS Docs. This is an open learning space where I share what I'm discovering about prompt engineering and agent design. Whether you want to fix a typo, add examples, improve documentation, or share your own patterns — you're welcome here.
 
 ---
 
@@ -97,6 +97,6 @@ How the model should handle ambiguity
 * Open an issue with your idea
 * Or contact David Edwards directly via GitHub
 
-Let’s build AI blueprints worth sharing.
+Let's learn and build together.
 
-— Pineapple Labs 🍍
+— David Edwards / Pineapple Lab 🍍

--- a/Pineapple_Lab_TOE_Context_Engineering_for_Agents.md
+++ b/Pineapple_Lab_TOE_Context_Engineering_for_Agents.md
@@ -1,7 +1,9 @@
 # Truth Optimization Engine (TOE): Context Engineering for AI Agents
-## Production-Ready AI Systems with Verified Output Quality
+## A Practitioner's Framework for AI Honesty and Reliability
 
-*Part of the Pineapple Lab OS Docs - Advanced AI Systems Research*
+*Part of the Pineapple Lab OS Docs - Practitioner's Guide Series*
+
+**Important Context:** This document describes a framework I've developed for encouraging AI honesty, based on existing research and best practices. It represents my synthesis and organization of techniques from AI safety research, model calibration work, software engineering practices, and official documentation from AI labs. **This is not peer-reviewed academic research** — it's a practitioner's framework from building real production systems.
 
 **Referenced from**: [Prompt Engineering Blueprint](Prompt_Engineering_Blueprint.md) - This document provides production implementation of Truth Optimization principles introduced in the Blueprint.
 
@@ -12,22 +14,26 @@
 
 ---
 
-## Research Overview
+## Framework Overview
 
-This document presents research on three interconnected AI verification systems designed to solve a fundamental problem: **How do we ensure AI generates code that actually works in production?**
+This document describes three interconnected AI verification approaches I've developed and tested while building production AI systems at Pineapple Lab.
 
-The research focuses on three core systems:
-1. **Truth Optimization Engine (TOE)** - Prompt engineering for AI honesty
-2. **Benchmarking Loop System** - Continuous verification against real problems
-3. **Live Documentation Index** - Context management for large codebases
+**Context:** These are practitioner frameworks based on my experience building AI products, not formal research studies. They build on established techniques from AI safety research, software engineering best practices, and official documentation from AI labs.
 
-These systems work together to create a feedback loop that continuously improves AI output quality.
+**The fundamental problem:** How do we ensure AI generates code that actually works in production?
+
+**Three core systems I've developed:**
+1. **Truth Optimization Engine (TOE)** - Prompt engineering techniques for AI honesty
+2. **Benchmarking Loop System** - Continuous verification against real-world problems
+3. **Live Documentation Index** - Context management strategies for large codebases
+
+These systems work together to create a feedback loop that improves AI output quality.
 
 ---
 
 ## System 1: Truth Optimization Engine (TOE)
 
-### Research Problem
+### The Problem
 
 AI systems often generate code that looks correct but fails in practice. This manifests as:
 - Placeholder implementations that don't function
@@ -35,16 +41,20 @@ AI systems often generate code that looks correct but fails in practice. This ma
 - Claims of working features that don't work
 - Missing error handling and edge cases
 
-### Research Approach
+### My Approach
 
-The key insight is that **truth-telling can be easier than lying** if we engineer prompts correctly. The research explores prompt engineering techniques that make honesty the path of least resistance.
+The key insight is that **truth-telling can be easier than lying** if we engineer prompts correctly. I've explored and tested prompt engineering techniques that make honesty the path of least resistance.
 
-### Methodology
+**Where this comes from:** AI safety research, model calibration work (Guo et al., 2017), Anthropic's documentation on AI honesty, and standard software documentation practices.
+
+### Techniques I've Found Effective
 
 #### Technique 1: Explicit Uncertainty Acknowledgment
-**Research Finding**: When AI is explicitly allowed to express uncertainty, it becomes more honest about limitations.
+**What I've Observed**: When AI is explicitly allowed to express uncertainty, it becomes more honest about limitations.
 
 **Method**: Add uncertainty markers and explicit permission to say "I don't know" to prompts.
+
+**Source**: This builds on model calibration research and AI safety practices.
 
 **Example - Before TOE**:
 ```
@@ -66,12 +76,14 @@ AI Response: "Here's an authentication component:
 Implementation: [actual code with uncertainty markers]"
 ```
 
-**Result**: 85% reduction in false claims about functionality.
+**My Observation**: In my experience building AI agents for Pineapple Lab, this approach has significantly reduced instances where AI makes overconfident claims without basis. The improvement has been substantial and consistent across different types of tasks. I haven't conducted formal benchmarking with controlled conditions, so I can't provide quantitative metrics yet.
 
 #### Technique 2: Assumption Transparency
-**Research Finding**: Forcing AI to list assumptions makes reasoning transparent and identifies potential issues.
+**What I've Observed**: Requiring AI to list assumptions makes reasoning transparent and helps identify potential issues early.
 
 **Method**: Require AI to explicitly state all assumptions with reasoning.
+
+**Source**: Standard software documentation practices and debugging methodologies.
 
 **Example - Before TOE**:
 ```
@@ -100,10 +112,10 @@ ASSUMPTIONS I'M MAKING:
 Implementation: [actual code with assumption tracking]"
 ```
 
-**Result**: 70% improvement in identifying potential failure points.
+**My Observation**: Assumption transparency has noticeably improved my ability to identify potential failure points before they become issues in production. Many bugs have been caught at the prompting stage rather than in testing or production.
 
 #### Technique 3: Limitation Disclosure
-**Research Finding**: Making it natural to mention limitations prevents overconfidence.
+**What I've Observed**: Making it natural to mention limitations prevents overconfidence and sets realistic expectations.
 
 **Method**: Structure prompts to encourage discussion of potential issues and alternatives.
 
@@ -132,10 +144,10 @@ ALTERNATIVES TO CONSIDER:
 Implementation: [actual model code with limitation notes]"
 ```
 
-**Result**: 60% reduction in overconfident responses.
+**My Observation**: Encouraging limitation disclosure has substantially reduced overconfident responses in my work. AI is much more likely to mention caveats, edge cases, and when to consider alternative approaches.
 
 #### Technique 4: Honest Reporting Framework
-**Research Finding**: Structured response formats encourage systematic honesty.
+**What I've Observed**: Structured response formats encourage systematic honesty and make it natural to separate confident knowledge from uncertainty.
 
 **Method**: Provide templates that make it natural to separate confident knowledge from uncertainty.
 
@@ -176,10 +188,10 @@ POTENTIAL ISSUES:
 IMPLEMENTATION: [actual code with these considerations built in]"
 ```
 
-**Result**: 90% improvement in response accuracy.
+**My Observation**: Structured response formats have dramatically improved response accuracy in my experience. When AI is required to organize thinking this way, it's much more thorough and honest about limitations.
 
 #### Technique 5: Unit Testing Requirements
-**Research Finding**: Mandatory testing requirements force AI to consider actual functionality.
+**What I've Observed**: Requiring tests forces AI to think about actual functionality rather than just generating code that looks right.
 
 **Method**: Require working unit tests for all generated code.
 
@@ -224,10 +236,10 @@ describe('registerUser', () => {
 These tests actually validate the function works correctly."
 ```
 
-**Result**: 95% improvement in code functionality.
+**My Observation**: Requiring unit tests has been the single most effective technique for ensuring code functionality in my work. Almost all code generated with explicit test requirements actually works as intended, compared to frequent failures without this requirement. This is probably because tests force concrete thinking about inputs, outputs, and edge cases.
 
 #### Technique 6: Benchmarking Integration
-**Research Finding**: Real-world testing requirements prevent theoretical-only solutions.
+**What I've Observed**: Real-world testing requirements prevent theoretical-only solutions and encourage practical implementations.
 
 **Method**: Require code to pass actual benchmarks and integration tests.
 
@@ -269,7 +281,7 @@ INTEGRATION TESTS:
 This implementation has been tested against real data and meets performance benchmarks."
 ```
 
-**Result**: 80% improvement in production readiness.
+**My Observation**: Benchmark validation requirements have significantly improved production readiness of generated code. Code that must meet specific benchmarks is much more likely to be production-quality from the start.
 
 ### Wireframe: Truth Optimization Process
 
@@ -313,26 +325,38 @@ This implementation has been tested against real data and meets performance benc
                                                └─────────────────┘
 ```
 
-### Research Results
+### Observed Outcomes (Informal)
 
-- **Confidence Accuracy**: 95% correlation between stated confidence and actual performance
-- **Code Functionality**: 95% of generated code actually works as intended
-- **Test Quality**: 90% of generated tests provide meaningful coverage
-- **Error Handling**: 85% improvement in proper error handling
+**Important Caveat**: These are my informal observations from building Pineapple Lab products, not results from controlled experiments. Proper validation would require:
+- Formal methodology with clear metrics
+- Large sample sizes (1000+ prompts)
+- Blind evaluation by multiple raters
+- Statistical significance testing
+- Peer review
+
+**My Informal Observations**:
+- **Confidence Correlation**: Stated confidence levels generally match actual outcomes in my experience
+- **Code Functionality**: Most code generated with TOE techniques works as intended (especially with test requirements)
+- **Test Quality**: Tests generated with explicit requirements tend to be more meaningful and comprehensive
+- **Error Handling**: Substantial improvement in proper error handling when explicitly required in prompts
+
+**Status**: These observations need formal research to validate. If you're interested in conducting rigorous testing of these techniques, I'd love to collaborate.
 
 ---
 
 ## System 2: Benchmarking Loop System
 
-### Research Problem
+### The Problem
 
 How do we verify that AI-generated code works on real problems, not just theoretical scenarios?
 
 **Important Distinction**: This system is separate from unit test generation. It's specifically for testing production bug fixes against real-world issues.
 
-### Research Approach
+### My Approach
 
 Create a continuous feedback loop where AI-generated code is tested against real-world benchmarks, and failures trigger iterative improvement.
+
+**Where this comes from**: Software engineering best practices, continuous integration/deployment methodologies, and existing benchmark systems from the research community (SWE-Bench, AgentBench, etc.).
 
 **Key Difference from Unit Testing**: 
 - **Unit Tests**: Test specific methods with specific inputs
@@ -452,13 +476,19 @@ Verification:
 - Issue resolved: ✅
 ```
 
-### Research Results
+### Benchmarking Plans
 
-- **SWE-Bench Success Rate**: 64% on real GitHub issues
-- **AgentBench Accuracy**: 78% on multi-agent tasks
-- **Commit0 Success Rate**: 82% on code generation
-- **CI Build Repair**: 54% on build failure resolution
-- **Iterative Improvement**: 15% improvement per iteration cycle
+**Important**: I'm referencing benchmark systems (SWE-Bench, AgentBench, Commit0) that exist in the research community. I haven't personally run formal benchmarks on my systems yet. This is on my roadmap for proper validation.
+
+**These are examples of benchmarks I plan to test against**, not results I've achieved:
+- **SWE-Bench**: Real GitHub issues for testing code fixes
+- **AgentBench**: Multi-agent task scenarios
+- **Commit0**: Code generation benchmarks  
+- **CI Build Repair**: Build failure resolution tests
+
+**Current Status**: I use these informally during development to test my AI systems. Formal benchmarking with proper methodology, controlled conditions, and statistical analysis is planned for 2025 Q2.
+
+**Why I'm sharing this**: Even though I haven't run formal benchmarks yet, the concept of continuous benchmarking against real-world problems has been valuable in my development process. I wanted to document the approach for others who might implement it more rigorously.
 
 ### When to Use This System
 
@@ -478,15 +508,17 @@ Verification:
 
 ## System 3: Live Documentation Index & Memory System
 
-### Research Problem
+### The Problem
 
 How do we enable AI to work effectively on large codebases that exceed context window limitations?
 
-### Research Approach
+### My Approach
 
 Create a human-like memory system that provides persistent knowledge about codebases, allowing AI to work efficiently regardless of project size.
 
-### Methodology
+**Where this comes from**: Inspired by systems like OpenHands, practices from Anthropic and other AI labs, and standard software documentation approaches. My contribution is organizing and documenting practical implementation patterns.
+
+### Implementation Approach
 
 #### Step 1: Live Documentation Generation
 When someone accesses a repository, the system automatically creates comprehensive documentation:
@@ -699,13 +731,17 @@ Result: Efficient, focused, human-like development
 - Focuses on specific task area
 - Provides accurate, contextual responses
 
-### Research Results
+### Observed Benefits
 
-- **Large Codebase Support**: Successfully handles 100k+ line projects
-- **Context Efficiency**: 80% reduction in context window usage
-- **Memory Retention**: 90% of critical information preserved
-- **Context Relevance**: 85% of recalled information is task-relevant
-- **Scalability**: Works regardless of project size
+**My Experience**: These are observations from implementing memory systems in my AI agents, not controlled research results.
+
+- **Large Codebase Support**: Handles 100k+ line projects effectively in my testing
+- **Context Efficiency**: Substantial reduction in wasted context window usage
+- **Memory Retention**: Most critical information is preserved through condensation
+- **Context Relevance**: Information recalled tends to be relevant to current tasks
+- **Scalability**: Approach scales to projects of varying sizes
+
+**Note**: Proper validation would require formal testing with controlled conditions and quantitative metrics. These are qualitative observations from practical use.
 
 ---
 
@@ -754,14 +790,14 @@ if (options.enableBenchmarkTesting === true) {
 
 ## Integration: How Systems Work Together
 
-### Research Finding
+### What I've Observed
 
 The three systems create a synergistic effect when used together, with each system enhancing the others.
 
-### Integration Methodology
+### Integration Approach
 
 #### Truth Optimization + Benchmarking
-**Research Finding**: Truth optimization improves benchmark success rates.
+**What I've Observed**: Truth optimization improves benchmark success rates.
 
 **Method**: Use truth-optimized prompts when generating code for benchmarks.
 
@@ -773,11 +809,11 @@ backend API structure, say so. List any assumptions about the database schema.
 Only provide solutions you're confident will work."
 
 Result: AI provides more honest assessment and better solutions
-Benchmark Success Rate: 20% improvement
+Improvement: Noticeable in my testing
 ```
 
 #### Benchmarking + Memory System
-**Research Finding**: Context-aware benchmarking provides more accurate results.
+**What I've Observed**: Context-aware benchmarking provides more accurate results.
 
 **Method**: Use memory system to provide full context during benchmark testing.
 
@@ -786,11 +822,11 @@ Benchmark Success Rate: 20% improvement
 Benchmark Test: Fix failing test in large codebase
 Memory Context: Architecture overview, testing patterns, recent changes
 Result: AI understands codebase structure and testing conventions
-Benchmark Accuracy: 15% improvement
+Improvement: Better context understanding in my testing
 ```
 
 #### Memory System + Truth Optimization
-**Research Finding**: Context-aware truth optimization produces more relevant results.
+**What I've Observed**: Context-aware truth optimization produces more relevant results.
 
 **Method**: Use memory system to inform truth optimization strategies.
 
@@ -800,78 +836,109 @@ User Request: Add new feature to existing codebase
 Memory Context: Current architecture, patterns, conventions
 Truth Optimization: Tailored to specific codebase context
 Result: More relevant and honest responses
-Context Relevance: 25% improvement
+Improvement: Noticeably better in my experience
 ```
 
-### Research Results
+### My Observations on Integration (Informal)
 
-- **Combined Effectiveness**: 40% improvement over individual systems
-- **Error Reduction**: 60% reduction in context-related errors
-- **Quality Improvement**: 35% improvement in overall code quality
-- **Efficiency Gain**: 50% reduction in iteration cycles
+**Important Caveat**: These are informal observations from my work, not scientifically validated results.
 
----
+**What I've Observed**:
+- Systems work better together than separately
+- Context-related errors are noticeably reduced
+- Overall code quality improves substantially
+- Development iteration cycles are faster
 
-## Research Contributions
-
-### Novel Approaches
-
-1. **Truth Optimization Engine**: First systematic approach to prompt engineering for AI honesty
-2. **Benchmarking Loop System**: Continuous verification against real-world problems
-3. **Memory System**: Human-like context management for large codebases
-4. **Integration Framework**: Synergistic combination of verification systems
-
-### Technical Innovations
-
-- **Uncertainty Acknowledgment**: Making honesty easier than deception
-- **Assumption Transparency**: Forcing explicit reasoning disclosure
-- **Context-Aware Verification**: Using memory for better verification
-- **Iterative Benchmarking**: Learning from failures to improve
-
-### Research Impact
-
-- **Code Quality**: 95% improvement in generated code functionality
-- **Reliability**: 90% reduction in false claims about functionality
-- **Scalability**: Support for 100k+ line codebases
-- **Efficiency**: 50% reduction in development iteration cycles
+**What This Needs**: Formal research methodology, proper metrics, controlled testing, and peer review to validate these observations.
 
 ---
 
-## Future Research Directions
+## My Contributions to the Community
 
-### Advanced Truth Optimization
+### What I've Built:
 
-- **Neural Truth Networks**: Deep learning approaches to truth detection
-- **Quantum Truth Verification**: Exploring quantum computing for verification
-- **Distributed Truth Consensus**: Blockchain-based verification systems
+1. **Truth Optimization Engine Framework**: A systematic organization of AI honesty techniques, synthesizing practices from AI safety research, model calibration work, and software engineering
+2. **Benchmarking Loop Framework**: Documentation of continuous verification approaches (based on existing benchmark research from the community)
+3. **Memory System Framework**: Practical implementation patterns for context management in large codebases (inspired by OpenHands and practices from major AI labs)
+4. **Integration Documentation**: How these techniques work together in practice
 
-### Enhanced Benchmarking
+### What Makes This Useful:
 
-- **Real-World Task Benchmarks**: Production environment testing
-- **Multi-Modal Verification**: Text, code, and visual output validation
-- **Continuous Learning Benchmarks**: Adaptive system evaluation
+- **Synthesis**: Compiled scattered techniques from multiple sources into one coherent framework
+- **Practical Examples**: Real-world applications from building production systems  
+- **Honest Documentation**: Clear about what works, what's uncertain, and what needs testing
+- **Open Sharing**: Making my learnings available to save others time
 
-### Memory System Evolution
+### What This Is NOT:
 
-- **Semantic Memory Networks**: Advanced knowledge representation
-- **Cross-Repository Intelligence**: Multi-project knowledge sharing
-- **Temporal Memory Optimization**: Time-aware information retrieval
+- Novel academic research  
+- Peer-reviewed findings
+- Invention of new techniques
+- Scientifically validated results
+
+### The Value:
+
+You could spend months reading scattered documentation and papers to learn these techniques. Or you can read my organized synthesis and practical examples. That's the service I provide: **curation, organization, and practical application guidance**.
+
+---
+
+## Future Development Plans
+
+### **I Want to Contribute Actual Research Eventually**
+
+My current work is synthesis and application. But I'm interested in eventually contributing genuine research if my work uncovers novel findings.
+
+### **Planned Formal Validation (2025)**
+
+- **Benchmarking Study**: Formally test TOE techniques against standard benchmarks (SWE-Bench, etc.)
+- **Quantitative Analysis**: Replace informal observations with actual data
+- **Methodology**: Proper experimental design, controls, statistical analysis
+- **Peer Review**: Submit findings for review if results are significant
+- **Collaboration**: Work with academic researchers for credibility and rigor
+
+### **Potential Novel Research Areas**
+
+If my work uncovers genuinely novel insights:
+- **Domain-Specific Patterns**: Unique patterns for PropTech/Real Estate AI applications
+- **Production System Learnings**: Insights from large-scale deployment
+- **Failure Analysis**: Systematic study of what doesn't work and why
+- **Tool Development**: Novel tools for automated prompt optimization
+
+### **Honest Timeline**
+
+- **2025 Q2**: Complete formal benchmarking with proper methodology
+- **2025 Q3**: Analysis and write-up of results
+- **2025 Q4**: Submit for peer review (if results warrant publication)
+- **2026+**: Potential academic partnership or PhD if research direction proves promising
+
+**I'm not there yet. But this is the path from "builder who documents" to "builder who researches."**
 
 ---
 
 ## Conclusion
 
-This research demonstrates that **AI verification is not just possible, but essential** for production use. The three systems work together to create a comprehensive verification framework that:
+This framework demonstrates that **AI verification is achievable** through systematic approaches:
 
-1. **Ensures Honesty**: Truth optimization makes AI more honest about capabilities
-2. **Validates Functionality**: Benchmarking proves code works in real scenarios
-3. **Manages Context**: Memory system enables work on large codebases
-4. **Improves Continuously**: Integration creates synergistic improvements
+1. **Honesty is Engineerable**: Prompt engineering can encourage AI to be more honest about capabilities and limitations
+2. **Testing is Essential**: Benchmarking against real-world problems improves code quality
+3. **Context Management Works**: Memory systems enable effective work on large codebases
+4. **Integration Matters**: Systems work better together than separately
 
-The research shows that **AI can be made reliable and trustworthy** through systematic verification approaches, opening the door to widespread adoption in production environments.
+**What This Proves:**
+Through practical application in production systems at Pineapple Lab, these techniques improve AI reliability and trustworthiness.
+
+**What This Doesn't Prove:**
+Without formal research methodology, I can't make quantitative claims or scientific conclusions. This is practitioner knowledge from building real systems, not peer-reviewed science.
+
+**What I Hope:**
+This framework saves you time and provides a starting point for your work. If you build on this and discover improvements, please share your findings. If you're interested in formal research collaboration, let's talk.
+
+**The Journey Continues:**
+I'm 21, learning in public, and documenting what I discover as I build. This is where I am now. Where I'll be in 5 years depends on what I learn along the way.
 
 ---
 
-**Research Team**: Friday Unified Development Team  
-**Date**: January 2025  
-**License**: Apache-2.0 (Open Source)
+**Framework Developer**: David Edwards, Pineapple Lab  
+**Date**: October 2025  
+**License**: Apache-2.0 (Open Source)  
+**Status**: Practitioner Framework (Not Peer-Reviewed Research)

--- a/Prompt Engineering Blue Print.md
+++ b/Prompt Engineering Blue Print.md
@@ -10,17 +10,19 @@
 
 ## 🔗 Purpose of This Guide
 
-This guide is part of an evolving set of findings from Pineapple Labs. I'm David Edwards, and this blueprint represents my ongoing exploration into prompt engineering as it relates to the broader field of AI engineering.
+This guide is part of my learning journey at Pineapple Lab. I'm David Edwards, and this blueprint represents how I've organized and synthesized prompt engineering knowledge from multiple sources.
 
-The idea behind publishing this is to open-source the design patterns, techniques, and structures I've found useful when working with LLMs like GPT, Claude, DeepSeek, and Gemini. Prompting isn't just about formatting text — it's about shaping behavior, logic, and reliability inside intelligent systems.
+The idea behind publishing this is to share the design patterns, techniques, and structures I've found useful when working with LLMs like GPT, Claude, DeepSeek, and Gemini. Prompting isn't just about formatting text — it's about shaping behavior, logic, and reliability inside intelligent systems.
 
-**This Blueprint is the master methodology** that integrates all Pineapple Lab techniques:
-- **Truth Optimization Engine (TOE)** - Woven throughout all 7 components
-- **XML Tag Structuring** - Referenced for advanced organization
-- **Chain-of-Thought Reasoning** - Integrated into Logic Block
-- **Context Engineering** - Applied for production AI agents
+**Important Context:** This blueprint integrates techniques from multiple authoritative sources (Anthropic, Google, OpenAI, academic research) into one cohesive framework. I didn't invent these individual techniques — I've organized them into a systematic approach that works for me.
 
-The goal is to make these findings public, collaborative, and useful — not just for Pineapple Labs, but for builders, researchers, and technologists everywhere who care about designing more trustworthy, performant agents.
+**This Blueprint integrates:**
+- **Truth Optimization Engine (TOE)** - My framework synthesizing AI honesty techniques, woven throughout all 7 components
+- **XML Tag Structuring** - Anthropic's technique, referenced for advanced organization
+- **Chain-of-Thought Reasoning** - Wei et al. & Kojima et al.'s research, integrated into Logic Block
+- **Context Engineering** - Best practices from multiple sources, applied for production AI agents
+
+The goal is to make this knowledge accessible and useful — for builders, learners, and anyone building with AI who wants practical, organized guidance.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # 🧠 Pineapple Lab OS Docs
 
-Welcome to **Pineapple Lab OS Docs** — the definitive open-source resource for advanced prompt engineering, context engineering, and AI agent design.
+Welcome to **Pineapple Lab OS Docs** — a practitioner's guide to prompt engineering, compiling and organizing techniques from Anthropic, Google, OpenAI, and academic research.
 
-This repository shares Pineapple Labs' research, methodologies, and practical frameworks for building reliable, production-ready AI systems. From beginner-friendly introductions to advanced reasoning frameworks, we provide comprehensive, research-backed guidance for engineering AI behavior.
+This repository shares how I've learned, organized, tested, and applied prompt engineering best practices while building AI products at Pineapple Lab. From beginner-friendly introductions to advanced reasoning frameworks, this is a comprehensive learning resource built on the shoulders of giants.
 
-> 🧪 **I'm David Edwards.** This repo is where I collect findings, test ideas, and publish what works — and what doesn't — in building composable, safe, and production-minded AI agents.
+> 🧪 **I'm David Edwards.** I'm 21, building AI products in South Africa, and I love to learn. This repo is where I organize what I learn from brilliant researchers and engineers, test it in real projects, and share it so others don't have to spend months reading scattered documentation like I did.
 
-You're welcome to fork, clone, copy, remix, and apply this material to your engineering teams, research work, or agent runtime stacks.
+You're welcome to fork, clone, copy, remix, and apply this material to your work.
 
-**Contributions, feedback, and wild ideas are all welcome — this is a lab, not a product.**
+**Contributions, feedback, and honest corrections are all welcome — I'm learning in public.**
 
 ---
 
@@ -27,19 +27,19 @@ Building production AI systems? Explore our specialized guides on [XML Tag Struc
 
 ## 🌍 Purpose
 
-This repo is part of the **Pineapple Lab OS** — a growing open-source hub for publishing Pineapple Labs' research, tooling, and findings around AI systems.
+This repo is where I organize and share what I'm learning about prompt engineering as I build AI products.
 
-At its core, Pineapple Lab OS is about **building a public R&D hub for the AI community**. The documents and blueprints here are based on real experiments, systems design efforts, and exploratory research. We believe in transparent collaboration and open sourcing not just code, but thinking.
+At its core, this is about **learning in public and helping others**. The documents here are based on studying official documentation from AI labs (Anthropic, Google, OpenAI), reading academic papers (Wei et al., Kojima et al., and others), and testing everything while building real products like RITA and OS Brick.
 
 ### This Project Exists To:
 
-- 📚 Publish **tested, reusable prompting patterns** for GPT, Claude, DeepSeek, and Gemini
-- 🏗️ Develop a **modular design system** for sophisticated AI agent behavior
-- 🔬 Share **research-backed methodologies** for improving AI reliability and honesty
-- 🤝 Invite **open-source contributions** from fellow builders and researchers
-- 🚀 Advance the **state of the art** in prompt engineering and context engineering
+- 📚 Organize **tested, reusable prompting patterns** for GPT, Claude, DeepSeek, and Gemini
+- 🏗️ Share a **systematic framework** for prompt engineering that I've found helpful
+- 🔬 Compile **techniques from research and industry** in one accessible place
+- 🤝 Invite **open-source contributions** from fellow builders and learners
+- 🚀 Make prompt engineering **accessible and practical** for everyone
 
-This is not a static spec — it's an **evolving playbook** for how we build LLM systems, and an open call for collaboration.
+This is not a static spec — it's an **evolving learning journal**, and an open invitation to learn together.
 
 ---
 
@@ -69,6 +69,34 @@ This is not a static spec — it's an **evolving playbook** for how we build LLM
 
 ---
 
+---
+
+## 🎯 What This Repository IS and IS NOT
+
+### ✅ What This IS:
+- **A practitioner's synthesis** of prompt engineering techniques from multiple authoritative sources
+- **Organized documentation** of what works in real production applications
+- **Real-world examples** from building AI products (RITA, OS Brick, and other Pineapple Lab projects)
+- **Learning resource** structured from beginner to advanced
+- **My personal framework** for organizing and applying prompt engineering knowledge
+- **Honest curation** of brilliant work by researchers and engineers at major AI labs
+
+### ❌ What This IS NOT:
+- Novel academic research (I cite the researchers who did that work)
+- Peer-reviewed or scientifically validated findings  
+- Claims of breakthrough innovations or inventions
+- Replacement for official documentation from AI labs
+- Formal benchmarking studies with controlled experiments
+
+### 🎓 My Contribution:
+I'm a 21-year-old builder learning in public. I've spent months reading documentation from Anthropic, Google, and OpenAI. I've studied academic papers like Wei et al.'s Chain-of-Thought (19,810+ citations) and Kojima et al.'s Zero-Shot CoT. I've tested these techniques extensively while building real AI products.
+
+**What I'm sharing:** My organization of this knowledge, practical examples from my work, and patterns I've found effective. I didn't invent these techniques — I learned them from the brilliant researchers and engineers who did the hard work. I'm just organizing and documenting practical application.
+
+**Standing on the shoulders of giants:** All core techniques come from researchers at institutions and companies doing groundbreaking work. This repo is my way of climbing that mountain and documenting the path for others.
+
+---
+
 ## 🚀 Quickstart
 
 ### **For Complete Beginners:**
@@ -91,19 +119,19 @@ This is not a static spec — it's an **evolving playbook** for how we build LLM
 ## 🧠 Design Principles
 
 - **🎯 Clarity First** — Every prompt block is modular and intentional
-- **🏗️ Structure > Style** — We treat prompts like functions, not text
+- **🏗️ Structure > Style** — Treat prompts like functions, not text
 - **🔒 Security-Aware** — Special attention to injection risks and ambiguity
-- **🌐 Multi-Model** — Designed for Claude, GPT, DeepSeek, Gemini from the start
-- **🔬 Open Research** — Pineapple Labs is an open-source-first R&D space
-- **📊 Evidence-Based** — Methodologies backed by peer-reviewed research and real-world testing
+- **🌐 Multi-Model** — Tested across Claude, GPT, DeepSeek, and Gemini
+- **🔬 Learning in Public** — Sharing what I learn as I build
+- **📊 Research-Based** — Built on peer-reviewed research (properly cited) and real-world testing
 
 ---
 
-## 🔬 Research Methodologies
+## 🔬 Core Frameworks
 
-### **Core Framework: Seven-Component Blueprint**
+### **Seven-Component Blueprint**
 
-Our [Prompt Engineering Blueprint](Prompt_Engineering_Blueprint.md) provides a complete framework:
+The [Prompt Engineering Blueprint](Prompt_Engineering_Blueprint.md) I've organized provides a systematic framework based on best practices from multiple sources:
 
 1. **System Declaration** (Agent Role Definition) + XML `<role>` tags
 2. **Instruction Block** with clear task separation + XML `<instructions>` tags
@@ -119,13 +147,20 @@ Our [Prompt Engineering Blueprint](Prompt_Engineering_Blueprint.md) provides a c
 
 ### **Truth Optimization Engine (TOE)**
 
-A breakthrough methodology for improving AI honesty and reliability:
+A systematic framework for encouraging AI honesty and reliability:
 
+**What it is:** A collection of prompt engineering techniques that encourage models to express uncertainty, state assumptions, and acknowledge limitations. This builds on AI safety research, model calibration work (Guo et al., 2017), and standard software documentation practices.
+
+**Core Techniques:**
 - **Explicit Uncertainty Acknowledgment**: `[CONFIDENT]`, `[LIKELY]`, `[UNCERTAIN]` markers
 - **Assumption Transparency**: Making AI assumptions explicit
 - **Limitation Disclosure**: Honest about what AI can't do
 - **Honest Reporting Framework**: Structured honesty in responses
 - **Validation Requirements**: Built-in self-checking mechanisms
+
+**Where it comes from:** I've synthesized these techniques from AI safety research, Anthropic's work on AI honesty, and standard software practices. My contribution is organizing them into a coherent framework and providing practical examples.
+
+**Real-world testing:** In my experience building AI agents for Pineapple Lab products, these structured approaches have significantly reduced instances where AI generates non-functional code or makes overconfident claims. I haven't conducted formal benchmarking yet, so I can't provide quantitative metrics.
 
 **Learn more** → [TOE Context Engineering for Agents](Pineapple_Lab_TOE_Context_Engineering_for_Agents.md)
 
@@ -133,17 +168,20 @@ A breakthrough methodology for improving AI honesty and reliability:
 
 ### **Advanced Techniques**
 
-**XML Tag Structuring** ([Guide](XML_Tag_Structuring_Guide.md))
+**XML Tag Structuring** (Anthropic Best Practice) ([Guide](XML_Tag_Structuring_Guide.md))
+- **Source:** Documented by Anthropic in their official prompt engineering guide
+- **My contribution:** Extensive testing and practical examples from building AI agents
 - Semantic organization of prompt components
 - Particularly powerful with Claude models
 - Improves parseability and accuracy
 - Enables complex multi-component prompts
 
-**Chain-of-Thought Reasoning** ([Guide](Advanced_Logic_Building_Guide.md))
+**Chain-of-Thought Reasoning** (Wei et al., 2022; Kojima et al., 2022) ([Guide](Advanced_Logic_Building_Guide.md))
+- **Source:** Introduced by Wei et al. (2022) with 19,810+ citations, extended by Kojima et al. (2022)
+- **My contribution:** Practical application patterns and production examples
 - Explicit step-by-step problem solving
 - Zero-shot and few-shot CoT patterns
 - Validation and self-correction mechanisms
-- Research-backed (Wei et al. 2022, Kojima et al. 2022)
 
 **Advanced Conditional Logic** ([Guide](Advanced_Logic_Building_Guide.md))
 - Complex decision trees and branching logic
@@ -170,21 +208,21 @@ A comprehensive 30-minute introduction for complete beginners covering:
 - Clear learning path from beginner to advanced
 
 ### **XML Tag Structuring Guide** ✨ NEW
-Advanced methodology for organizing complex prompts:
+Practical guide to Anthropic's XML tag technique:
 - Core tag categories and best practices
 - Chain-of-thought integration with XML
 - Multi-component prompt patterns
 - Conditional logic with XML structure
-- Real-world implementation examples
+- Real-world implementation examples from my projects
 
 ### **Advanced Logic Building Guide** ✨ NEW
-Sophisticated reasoning frameworks:
-- Zero-shot and few-shot chain-of-thought
+Application of research-backed reasoning frameworks:
+- Zero-shot and few-shot chain-of-thought (Wei et al., Kojima et al.)
 - Multi-condition logic trees
 - Recursive reasoning patterns
 - Prompt chaining (sequential and parallel)
 - Self-correction and validation mechanisms
-- Error detection and recovery
+- Error detection and recovery patterns
 
 ---
 
@@ -193,28 +231,39 @@ Sophisticated reasoning frameworks:
 - `prompt_registry.json` — Structured schema for prompts-as-code
 - `tests/` — Prompt regression + consistency tests
 - `agent_templates/` — Blueprints for repeatable, role-specific agents
-- `whitepaper.md` — Outlining Pineapple Labs' approach to modular agents
 - **Integration examples** — Demonstrating XML + CoT + TOE together
-- **Performance benchmarks** — Empirical validation of methodologies
-- **Industry comparisons** — How we compare to Google, OpenAI, Anthropic approaches
+- **Formal benchmarks** — Proper testing methodology with controlled experiments
+- **Case studies** — Detailed examples from production systems with real data
+- **Video tutorials** — Walking through techniques with practical demonstrations
+- **Community patterns** — Collection of patterns from other practitioners
 
 ---
 
-## 🧬 A Note from Me
+## 🧬 A Note from David
 
-This project is the backbone of how I build AI agents for products like OS Brick. Whether you're exploring prompt chaining, ReAct logic, memory containerization, or persona design — this repo is yours to explore, extend, and question.
+Hey, I'm David Edwards. I'm 21, living in South Africa, and building AI products like RITA and OS Brick at Pineapple Lab.
 
-The recent additions represent significant advances in the field:
-- **Starting Guide** makes prompt engineering accessible to everyone
-- **XML Tag Structuring** provides industrial-strength organization
-- **Advanced Logic Building** enables sophisticated reasoning frameworks
-- **Truth Optimization Engine** ensures AI honesty and reliability
+**Here's the honest truth:** I'm not a PhD researcher or an AI scientist. I'm a builder who loves to learn. When I started with prompt engineering, I spent months reading scattered docs from Anthropic, Google, and OpenAI. I studied papers by Wei, Kojima, and others. It was overwhelming.
 
-These aren't just theoretical frameworks — they're battle-tested methodologies used in production AI systems.
+This repo is what I wish existed when I started: everything organized, practical examples from real projects, and a clear path from "complete beginner" to "building production systems."
 
-Thanks for being curious,
+**What makes this valuable:**
+- **Starting Guide** — I distilled months of learning into 30 minutes
+- **XML Tag Structuring** — Anthropic's technique with my real-world examples
+- **Advanced Logic Building** — Wei & Kojima's research applied to actual products
+- **Truth Optimization Engine** — My framework for AI honesty, synthesized from multiple sources
 
-**– David Edwards / Pineapple Labs**
+**I didn't invent these techniques.** But I've tested them for hundreds of hours, organized them coherently, and documented what actually works in production.
+
+**Why I'm sharing:** I believe in learning in public. I'm standing on the shoulders of giants and documenting the climb so you don't have to figure it all out alone like I did.
+
+**Feedback is gold:** If you spot errors, have suggestions, or discover better patterns — please contribute. I'm learning too, and honest corrections make this better for everyone.
+
+Thanks for being curious and learning with me,
+
+**– David Edwards**  
+*21-year-old builder, learning in public*  
+*Pineapple Lab, South Africa*
 
 ---
 
@@ -341,25 +390,25 @@ We're building an interactive tool that will allow you to:
 
 ---
 
-## 🏆 What Makes Pineapple Lab Different
+## 🏆 Why This Guide Exists
 
-### **Research-Backed**
-Every methodology is supported by peer-reviewed research or extensive real-world testing. We cite sources and validate claims.
+### **Honest About Sources**
+Every technique is properly attributed. I cite the researchers (Wei et al., Kojima et al.) and companies (Anthropic, Google, OpenAI) who did the original work. My contribution is organization and practical application.
 
 ### **Comprehensive Coverage**
-From complete newbie to advanced production systems — we cover the full spectrum with appropriate depth at each level.
+From complete newbie to advanced production systems — I've organized the full learning journey with appropriate depth at each level. This is what I wish existed when I started.
 
 ### **Practical Focus**
-Real-world examples, production-tested patterns, and actionable guidance. No theoretical fluff.
+Real-world examples from my work, production-tested patterns, and actionable guidance. No theoretical fluff — just what actually works.
 
 ### **Integration-First**
-All methodologies work together seamlessly. XML tags + Chain-of-thought + Truth Optimization = Powerful, reliable AI systems.
+I show how techniques work together: XML tags + Chain-of-thought + Truth Optimization patterns = More reliable AI systems.
 
-### **Open & Collaborative**
-Built by the community, for the community. Your contributions make this better for everyone.
+### **Learning in Public**
+Built to share knowledge openly. Your contributions and corrections make this better for everyone.
 
 ### **Multi-Model**
-Techniques tested across GPT (OpenAI), Claude (Anthropic), Gemini (Google), and DeepSeek. Model-agnostic where possible.
+Techniques I've tested across GPT (OpenAI), Claude (Anthropic), Gemini (Google), and DeepSeek.
 
 ---
 
@@ -461,22 +510,88 @@ This project is licensed under the **Apache 2.0 License** - see the [LICENSE](LI
 
 ---
 
-## 🌟 About Pineapple Lab
+## 🎓 My Actual Contributions
 
-📚 **Pineapple Lab – Open Research & Publications**
+To be completely transparent about what I've added vs. what I learned from others:
 
-At Pineapple Lab, we believe in building openly and collaboratively. Our research and technical blueprints are made freely available to the community to learn from, use, and improve upon. These resources are published to share our insights and experiments in AI, automation, and deep tech, advancing the field through transparent collaboration and evidence-based methodologies.
+### **Things I Learned From Others (With Credit):**
+- **Chain-of-Thought reasoning** → Wei et al. (2022), Kojima et al. (2022)
+- **XML tag structuring** → Anthropic official documentation
+- **Few-shot prompting** → Brown et al. (2020)
+- **System prompts, clear instructions** → Universal best practices from all major AI labs
+- **Prompt chaining concepts** → ReAct paper, AutoGPT, and agent research
+- **Model calibration** → Guo et al. (2017)
 
-**We're not building a product. We're building a movement toward more reliable, honest, and sophisticated AI systems.**
+### **Things I've Contributed:**
+1. **Organization:** Compiled scattered techniques from dozens of sources into one coherent framework
+2. **Examples:** Created 50+ specific examples from building PropTech AI agents (RITA, OS Brick)
+3. **Patterns:** Documented recurring patterns I've found effective in production
+4. **Synthesis:** Connected techniques from different sources into integrated workflows
+5. **Practical focus:** Emphasized what works in production vs. pure theory
+6. **Domain application:** Showed how to apply general techniques to specific domains
+7. **Learning path:** Created structured progression from beginner to advanced
+8. **TOE Framework:** Organized AI honesty techniques into a systematic approach
 
-Join us.
+### **The Real Value:**
+You could spend months reading Anthropic's docs, Google's docs, OpenAI's docs, and 20+ research papers. 
+
+Or you could read this guide where I've done that work and organized it for you.
+
+**That's the service I'm providing: curation, synthesis, and practical application guidance.**
 
 ---
 
-**Last Updated**: January 2025  
-**Version**: 2.0 (Major upgrade with beginner guide, XML structuring, and advanced logic)  
+## 🛣️ Roadmap: From Documentation to Research
+
+### **Current State (v2.0):**
+This is a practitioner's guide based on synthesis of existing work.
+
+### **Future Goals:**
+
+#### Short-term (Next 6 months)
+- [ ] Add 100+ more real-world examples from RITA and other Pineapple Lab products
+- [ ] Create video tutorials demonstrating techniques
+- [ ] Build community of practitioners sharing patterns
+- [ ] Document failure cases and anti-patterns  
+- [ ] Complete comprehensive bibliography with all sources
+
+#### Medium-term (6-12 months)
+- [ ] Conduct **formal benchmarking** with proper methodology
+- [ ] Collaborate with researchers to **validate claims** with data
+- [ ] Publish **case studies** with quantitative results from production
+- [ ] Open-source example codebases showing techniques in action
+- [ ] Present findings at conferences (as practitioner insights)
+
+#### Long-term (1-2 years)
+- [ ] If pursuing academic path: Partner with researchers on formal studies
+- [ ] Develop novel techniques specific to my domain (if they emerge)
+- [ ] Build tools that automate these patterns
+- [ ] Publish peer-reviewed papers (if warranted by genuine novel findings)
+
+### **The Journey:**
+I'm starting as a documenter and practitioner. My goal is to eventually contribute original research if I discover something genuinely novel. But I'm not there yet, and I won't pretend I am.
+
+**Honest positioning now → Credible voice later.**
+
+---
+
+## 🌟 About Pineapple Lab
+
+📚 **Pineapple Lab – Learning in Public**
+
+At Pineapple Lab, I believe in building openly and learning collaboratively. These resources are made freely available so others can learn from what I'm discovering, use what's helpful, and improve upon it.
+
+**I'm not claiming to revolutionize AI. I'm just sharing what I learn as I build, hoping it helps others on the same journey.**
+
+Learn with me.
+
+---
+
+**Last Updated**: October 2025  
+**Version**: 2.1 (Honest repositioning - practitioner's guide, not research)  
+**Previous**: v2.0 (Beginner guide, XML structuring, advanced logic)  
 **Repository**: [github.com/pineapple-lab/docs](https://github.com/pineapple-lab/docs)
 
 ---
 
-*Let's build smarter, more reliable AI systems together.* 🚀
+*Let's learn and build together, honestly.* 🚀

--- a/REPOSITIONING_ACTION_PLAN.md
+++ b/REPOSITIONING_ACTION_PLAN.md
@@ -1,0 +1,813 @@
+# Pineapple Lab OS Docs - Repositioning Action Plan
+## From "Breakthrough Research" to "Honest Practitioner's Synthesis"
+
+**Date:** October 1, 2025  
+**Author:** Elon Musk Mode Analysis  
+**Purpose:** Transform repository from overclaimed "research" to authentic "builder's guide"
+
+---
+
+## 🎯 Executive Summary
+
+**Current Problem:** Repository claims breakthrough research when it's actually high-quality synthesis and application of existing techniques.
+
+**Solution:** Reposition as "A practitioner's guide to prompt engineering, synthesizing techniques from Anthropic, Google, OpenAI, and academic research."
+
+**Impact:** Increased credibility, authentic positioning, foundation for long-term reputation building.
+
+---
+
+## 📊 Assessment Results
+
+### ✅ What's Actually Good (Keep This)
+- Excellent organization of scattered documentation
+- 50+ practical examples from real work
+- Clear learning progression (newbie → advanced)
+- Good integration of multiple sources
+- Practical focus on production applications
+- Honest attribution in some documents (XML guide)
+
+### ❌ What's Problematic (Fix This)
+- Claims of "breakthrough methodology"
+- Unsubstantiated quantitative metrics (85%, 95%)
+- Positioning as "research" and "novel approaches"
+- Terms like "Research Contributions" and "Technical Innovations"
+- Inconsistent attribution (some docs cite sources, others claim originality)
+- Missing "About Me" context about David's actual role
+
+### 🎯 Core Positioning Shift
+
+**FROM:**
+"Pineapple Lab OS Docs — breakthrough research in prompt engineering"
+
+**TO:**
+"Pineapple Lab OS Docs — A practitioner's guide to prompt engineering, synthesizing best practices from industry leaders and academic research"
+
+---
+
+## 📝 File-by-File Action Items
+
+### 1. README.md (MAJOR REWRITE)
+
+#### Changes Needed:
+
+**Line 3:** Current:
+```
+Welcome to **Pineapple Lab OS Docs** — the definitive open-source resource for advanced prompt engineering
+```
+
+**Change to:**
+```
+Welcome to **Pineapple Lab OS Docs** — a practitioner's guide to prompt engineering, compiling and organizing techniques from Anthropic, Google, OpenAI, and academic research
+```
+
+**Line 5:** Current:
+```
+This repository shares Pineapple Labs' research, methodologies, and practical frameworks
+```
+
+**Change to:**
+```
+This repository shares how I've organized, tested, and applied prompt engineering best practices while building AI products at Pineapple Lab
+```
+
+**Line 38:** Current:
+```
+- 🔬 Share **research-backed methodologies** for improving AI reliability and honesty
+```
+
+**Change to:**
+```
+- 🔬 Share **techniques based on academic research** (properly cited) for improving AI reliability and honesty
+```
+
+**Line 40:** Current:
+```
+- 🚀 Advance the **state of the art** in prompt engineering
+```
+
+**Change to:**
+```
+- 🚀 Make prompt engineering **accessible and practical** for builders and practitioners
+```
+
+**INSERT AFTER Line 42:** Add new section:
+```markdown
+---
+
+## 🎯 What This Repository IS and IS NOT
+
+### ✅ What This IS:
+- **A practitioner's synthesis** of prompt engineering techniques from multiple sources
+- **Organized documentation** of what works in production applications
+- **Real-world examples** from building AI products (RITA, OS Brick)
+- **Learning resource** structured from beginner to advanced
+- **My personal framework** for organizing prompt engineering knowledge
+
+### ❌ What This IS NOT:
+- Novel academic research (I cite the researchers who did that)
+- Peer-reviewed or scientifically validated findings
+- Claims of breakthrough innovations or inventions
+- Replacement for official documentation from AI labs
+- Formal benchmarking studies (though I'm working toward that)
+
+### 🎓 My Contribution:
+I've read the docs from Anthropic, Google, and OpenAI. I've studied the academic papers (Wei et al., Kojima et al.). I've tested these techniques extensively while building AI products. I've organized everything into a coherent, opinionated framework that's worked for me. That's what I'm sharing.
+
+**Standing on the shoulders of giants:** All core techniques come from the brilliant work of researchers and engineers at major AI labs. I'm just organizing and documenting practical application.
+```
+
+**Lines 120-131 (TOE Section):** Current:
+```markdown
+### **Truth Optimization Engine (TOE)**
+
+A breakthrough methodology for improving AI honesty and reliability:
+
+- **Explicit Uncertainty Acknowledgment**: `[CONFIDENT]`, `[LIKELY]`, `[UNCERTAIN]` markers
+- **Assumption Transparency**: Making AI assumptions explicit
+- **Limitation Disclosure**: Honest about what AI can't do
+- **Honest Reporting Framework**: Structured honesty in responses
+- **Validation Requirements**: Built-in self-checking mechanisms
+```
+
+**Change to:**
+```markdown
+### **Truth Optimization Engine (TOE)**
+
+A systematic framework for encouraging AI honesty and reliability:
+
+**What it is:** A collection of prompt engineering techniques that encourage models to express uncertainty, state assumptions, and acknowledge limitations. These techniques build on AI safety research and standard software documentation practices.
+
+**Where it comes from:**
+- Model calibration research (Guo et al., 2017)
+- Anthropic's work on AI honesty
+- Standard software documentation best practices
+- My testing and organization into a coherent framework
+
+**What I've observed:** In my experience building AI agents for Pineapple Lab products, applying these structured approaches has significantly reduced instances where AI generates non-functional code or makes overconfident claims. I haven't conducted formal benchmarking, so I can't provide quantitative metrics yet.
+
+**Core Techniques:**
+- **Explicit Uncertainty Acknowledgment**: `[CONFIDENT]`, `[LIKELY]`, `[UNCERTAIN]` markers
+- **Assumption Transparency**: Making AI assumptions explicit
+- **Limitation Disclosure**: Honest about what AI can't do
+- **Honest Reporting Framework**: Structured honesty in responses
+- **Validation Requirements**: Built-in self-checking mechanisms
+```
+
+**Lines 136-138 (XML Tags):** Current:
+```markdown
+**XML Tag Structuring** ([Guide](XML_Tag_Structuring_Guide.md))
+- Semantic organization of prompt components
+- Particularly powerful with Claude models
+```
+
+**Change to:**
+```markdown
+**XML Tag Structuring** (Anthropic Best Practice) ([Guide](XML_Tag_Structuring_Guide.md))
+- **Source:** Documented by Anthropic in their official prompt engineering guide
+- **My contribution:** Extensive testing and practical examples from building AI agents
+- Semantic organization of prompt components
+- Particularly powerful with Claude models
+```
+
+**Lines 142-146 (Chain-of-Thought):** Current:
+```markdown
+**Chain-of-Thought Reasoning** ([Guide](Advanced_Logic_Building_Guide.md))
+- Explicit step-by-step problem solving
+- Zero-shot and few-shot CoT patterns
+- Validation and self-correction mechanisms
+- Research-backed (Wei et al. 2022, Kojima et al. 2022)
+```
+
+**Change to:**
+```markdown
+**Chain-of-Thought Reasoning** (Wei et al., 2022; Kojima et al., 2022) ([Guide](Advanced_Logic_Building_Guide.md))
+- **Source:** Introduced by Wei et al. (2022) with 19,810+ citations, extended by Kojima et al. (2022)
+- **My contribution:** Practical application patterns and production examples
+- Explicit step-by-step problem solving
+- Zero-shot and few-shot CoT patterns
+- Validation and self-correction mechanisms
+```
+
+**Lines 203-214 (A Note from Me):** Current:
+```markdown
+## 🧬 A Note from Me
+
+This project is the backbone of how I build AI agents for products like OS Brick...
+
+The recent additions represent significant advances in the field:
+- **Starting Guide** makes prompt engineering accessible to everyone
+- **XML Tag Structuring** provides industrial-strength organization
+- **Advanced Logic Building** enables sophisticated reasoning frameworks
+- **Truth Optimization Engine** ensures AI honesty and reliability
+
+These aren't just theoretical frameworks — they're battle-tested methodologies used in production AI systems.
+```
+
+**Change to:**
+```markdown
+## 🧬 A Note from David
+
+I'm David Edwards, founder of Pineapple Lab in South Africa. I'm building AI-powered products (RITA, OS Brick) and learning as I go.
+
+**My background:** I'm not a PhD researcher or AI scientist. I'm an engineer and entrepreneur who's spent the last few years building with LLMs and learning from the brilliant work of teams at Anthropic, Google, OpenAI, and academic researchers.
+
+**What this project is:** This is my personal knowledge base made public. It's how I organize what I've learned from official documentation, research papers, and hundreds of hours of trial and error.
+
+**The recent additions:**
+- **Starting Guide** - Makes prompt engineering accessible by distilling complex docs
+- **XML Tag Structuring** - Anthropic's technique with my practical examples
+- **Advanced Logic Building** - Wei & Kojima's research applied to production
+- **Truth Optimization Engine** - My framework synthesizing AI safety practices
+
+These aren't just theoretical — they're techniques I use daily building real products. I'm sharing this because when I started, I wished someone had organized all this in one place. Now I'm that someone for the next person.
+
+**Feedback welcome:** If you spot errors, have suggestions, or want to share your own patterns, please contribute. This is a living document, not a finished product.
+```
+
+**Lines 344-360 (What Makes Pineapple Lab Different):** DELETE THIS ENTIRE SECTION or rewrite as:
+```markdown
+## 🏆 Why This Guide Exists
+
+### **Honest About Sources**
+Every technique is properly attributed to its source. I cite the researchers (Wei et al., Kojima et al.) and the companies (Anthropic, Google, OpenAI) who did the original work. My contribution is organization and practical application.
+
+### **Comprehensive Coverage**
+From complete newbie to advanced production systems — I've organized the full learning journey with appropriate depth at each level.
+
+### **Practical Focus**
+Real-world examples from my work, production-tested patterns, and actionable guidance. No theoretical fluff.
+
+### **Integration-First**
+I've shown how techniques work together: XML tags + Chain-of-thought + Truth Optimization patterns.
+
+### **Open & Collaborative**
+Built to share knowledge, for the community. Your contributions make this better for everyone.
+
+### **Multi-Model**
+Techniques I've tested across GPT (OpenAI), Claude (Anthropic), Gemini (Google), and DeepSeek.
+```
+
+**INSERT BEFORE References (after line 388):** Add new section:
+```markdown
+---
+
+## 🎓 My Actual Contributions
+
+To be completely transparent about what I've added vs. what I learned from others:
+
+### Things I Learned From Others (With Credit):
+- **Chain-of-Thought reasoning** → Wei et al. (2022), Kojima et al. (2022)
+- **XML tag structuring** → Anthropic official documentation
+- **Few-shot prompting** → Brown et al. (2020)
+- **System prompts, clear instructions** → Universal best practices from all major AI labs
+- **Prompt chaining concepts** → ReAct paper, AutoGPT, and agent research
+
+### Things I've Contributed:
+1. **Organization:** Compiled scattered techniques from dozens of sources into one coherent framework
+2. **Examples:** Created 50+ specific examples from my work building PropTech AI agents
+3. **Patterns:** Documented recurring patterns I've found effective in production
+4. **Synthesis:** Connected techniques from different sources into integrated workflows
+5. **Practical focus:** Emphasized what works in production vs. pure theory
+6. **Domain application:** Showed how to apply general techniques to specific domains (PropTech, AI agents)
+7. **Learning path:** Created a structured progression from beginner to advanced
+
+### The Real Value:
+You could learn all this by reading Anthropic's docs, Google's docs, OpenAI's docs, and 20+ research papers over several months. 
+
+Or you could read this guide where I've done that work and organized it for you.
+
+That's the service I'm providing: **curation, synthesis, and practical application guidance**.
+
+---
+
+## 🛣️ Roadmap: From Documentation to Research
+
+### **Current State (v2.0):**
+This is a practitioner's guide based on synthesis of existing work.
+
+### **Future Goals:**
+
+#### Short-term (Next 6 months)
+- [ ] Add 100+ more real-world examples from RITA and other Pineapple Lab products
+- [ ] Create video tutorials demonstrating techniques
+- [ ] Build community of practitioners sharing patterns
+- [ ] Document failure cases and anti-patterns
+- [ ] Complete bibliography with all sources properly cited
+
+#### Medium-term (6-12 months)
+- [ ] Conduct **formal benchmarking** of techniques with proper methodology
+- [ ] Collaborate with researchers to **validate claims** with data
+- [ ] Publish **case studies** with quantitative results from production systems
+- [ ] Open-source example codebases showing techniques in action
+- [ ] Present findings at conferences (as practitioner insights, not research)
+
+#### Long-term (1-2 years)
+- [ ] If pursuing PhD or partnering with academics: Contribute actual research
+- [ ] Develop novel techniques specific to my domain (if they emerge from work)
+- [ ] Build tools that automate these patterns
+- [ ] Create certification program for prompt engineering
+- [ ] Publish peer-reviewed papers (if warranted by actual novel findings)
+
+### **The Journey:**
+I'm starting as a documenter and practitioner. My goal is to eventually contribute original research if I discover something genuinely novel through my work. But I'm not there yet, and I won't pretend I am.
+
+**Honest positioning now → Credible voice later.**
+
+---
+```
+
+---
+
+### 2. Pineapple_Lab_TOE_Context_Engineering_for_Agents.md (MAJOR REWRITE)
+
+#### Changes Needed:
+
+**Lines 1-6:** Current:
+```markdown
+# Truth Optimization Engine (TOE): Context Engineering for AI Agents
+## Production-Ready AI Systems with Verified Output Quality
+
+*Part of the Pineapple Lab OS Docs - Advanced AI Systems Research*
+```
+
+**Change to:**
+```markdown
+# Truth Optimization Engine (TOE): Context Engineering for AI Agents
+## A Practitioner's Framework for AI Honesty and Reliability
+
+*Part of the Pineapple Lab OS Docs - Advanced AI Systems Practitioner's Guide*
+
+**Important Context:** This document describes a framework I've developed for encouraging AI honesty based on existing research and best practices. It represents my synthesis and organization of techniques from AI safety research, software engineering practices, and official documentation from AI labs. This is not peer-reviewed academic research.
+```
+
+**Lines 15-24:** Current:
+```markdown
+## Research Overview
+
+This document presents research on three interconnected AI verification systems designed to solve a fundamental problem...
+
+The research focuses on three core systems:
+```
+
+**Change to:**
+```markdown
+## Framework Overview
+
+This document describes three interconnected AI verification approaches I've developed and tested while building production AI systems:
+
+**Context:** These are practitioner frameworks based on my experience, not formal research studies. They build on established techniques from AI safety research, software engineering, and official AI lab documentation.
+
+These frameworks address a fundamental problem: **How do we ensure AI generates code that actually works in production?**
+
+The three core systems:
+```
+
+**Line 69:** Current:
+```markdown
+**Result**: 85% reduction in false claims about functionality.
+```
+
+**Change to:**
+```markdown
+**My Observation:** In my experience building AI agents for Pineapple Lab, I've observed significant reduction in cases where AI makes overconfident claims without basis. I haven't conducted formal benchmarking with controlled conditions, so I can't provide quantitative metrics, but the qualitative improvement has been substantial.
+```
+
+**Line 104:** Current:
+```markdown
+**Result**: 70% improvement in identifying potential failure points.
+```
+
+**Change to:**
+```markdown
+**My Observation:** Assumption transparency has noticeably improved my ability to identify potential failure points before they become issues in production. Formal quantification would require controlled testing.
+```
+
+**Line 136:** Current:
+```markdown
+**Result**: 60% reduction in overconfident responses.
+```
+
+**Change to:**
+```markdown
+**My Observation:** Encouraging limitation disclosure has substantially reduced overconfident responses in my work. Proper measurement would require formal benchmarking methodology.
+```
+
+**Line 180:** Current:
+```markdown
+**Result**: 90% improvement in response accuracy.
+```
+
+**Change to:**
+```markdown
+**My Observation:** Structured response formats have dramatically improved response accuracy in my experience. This needs formal validation with proper metrics.
+```
+
+**Line 228:** Current:
+```markdown
+**Result**: 95% improvement in code functionality.
+```
+
+**Change to:**
+```markdown
+**My Observation:** Requiring unit tests has been the single most effective technique for ensuring code functionality in my work. Almost all code generated with test requirements actually works as intended, compared to frequent failures without this requirement.
+```
+
+**Line 273:** Current:
+```markdown
+**Result**: 80% improvement in production readiness.
+```
+
+**Change to:**
+```markdown
+**My Observation:** Benchmark validation requirements have significantly improved production readiness of generated code.
+```
+
+**Lines 316-323:** Current:
+```markdown
+### Research Results
+
+- **Confidence Accuracy**: 95% correlation between stated confidence and actual performance
+- **Code Functionality**: 95% of generated code actually works as intended
+- **Test Quality**: 90% of generated tests provide meaningful coverage
+- **Error Handling**: 85% improvement in proper error handling
+```
+
+**Change to:**
+```markdown
+### Observed Outcomes (Informal)
+
+**Important Caveat:** These are my informal observations from building Pineapple Lab products, not results from controlled experiments. Proper validation would require:
+- Formal methodology
+- Large sample sizes (1000+ prompts)
+- Blind evaluation by multiple raters
+- Statistical significance testing
+- Peer review
+
+**My Informal Observations:**
+- **Confidence Correlation:** Stated confidence levels generally match actual outcomes in my experience
+- **Code Functionality:** Most code generated with TOE techniques works as intended
+- **Test Quality:** Tests generated with explicit requirements tend to be more meaningful
+- **Error Handling:** Substantial improvement in proper error handling when explicitly required
+
+**Status:** These observations need formal research to validate. If you're interested in conducting rigorous testing, let's collaborate.
+```
+
+**Lines 453-462:** Current:
+```markdown
+### Research Results
+
+- **SWE-Bench Success Rate**: 64% on real GitHub issues
+- **AgentBench Accuracy**: 78% on multi-agent tasks
+- **Commit0 Success Rate**: 82% on code generation
+- **CI Build Repair**: 54% on build failure resolution
+- **Iterative Improvement**: 15% improvement per iteration cycle
+```
+
+**Change to:**
+```markdown
+### Performance Notes
+
+**Important:** I'm referencing benchmark systems (SWE-Bench, AgentBench, Commit0) that exist in the research community. I haven't personally run these benchmarks on my systems yet. This is on my roadmap for formal validation.
+
+**These are examples of benchmarks I plan to test against**, not results I've achieved:
+- SWE-Bench: Real GitHub issues for testing code fixes
+- AgentBench: Multi-agent task scenarios
+- Commit0: Code generation benchmarks
+- CI Build Repair: Build failure resolution
+
+**Current Status:** I use these informally for development. Formal benchmarking with proper methodology is planned for 2025 Q2.
+```
+
+**Lines 807-813:** Current:
+```markdown
+### Research Results
+
+- **Combined Effectiveness**: 40% improvement over individual systems
+- **Error Reduction**: 60% reduction in context-related errors
+- **Quality Improvement**: 35% improvement in overall code quality
+- **Efficiency Gain**: 50% reduction in iteration cycles
+```
+
+**Change to:**
+```markdown
+### My Observations (Informal)
+
+**Important Caveat:** These are informal observations from my work, not scientifically validated results.
+
+**What I've Observed:**
+- Systems work better together than separately
+- Context-related errors are noticeably reduced
+- Overall code quality improves substantially
+- Development iteration cycles are faster
+
+**What This Needs:** Formal research methodology, proper metrics, controlled testing, and peer review to validate.
+```
+
+**Lines 815-839:** DELETE ENTIRE "Research Contributions" SECTION or rewrite as:
+
+```markdown
+---
+
+## My Contributions to the Community
+
+### What I've Built:
+
+1. **Truth Optimization Engine Framework**: A systematic approach to prompt engineering for AI honesty, synthesizing techniques from AI safety research and software engineering
+2. **Benchmarking Loop System**: A framework for continuous verification (based on existing benchmark research)
+3. **Memory System Framework**: Organization of context management techniques for large codebases (based on practices from OpenHands, Anthropic, and others)
+4. **Integration Documentation**: Showing how these techniques work together
+
+### What Makes This Useful:
+
+- **Synthesis**: I've compiled scattered techniques into one coherent framework
+- **Practical Examples**: Real-world applications from building production systems
+- **Honest Documentation**: Clear about what works, what's uncertain, and what needs testing
+- **Open Sharing**: Making my learnings available to save others time
+
+### What This Is NOT:
+
+- Novel academic research
+- Peer-reviewed findings
+- Invention of new techniques
+- Scientifically validated results
+
+### The Value:
+
+You could spend months reading scattered documentation and papers to learn these techniques. Or you can read my organized synthesis and practical examples. That's the service I provide.
+```
+
+**Lines 840-858:** DELETE "Future Research Directions" or rewrite as:
+
+```markdown
+---
+
+## Future Development and Research Plans
+
+### **I Want to Contribute Actual Research Eventually**
+
+My current work is synthesis and application. But I'm interested in eventually contributing genuine research if my work uncovers novel findings.
+
+### **Planned Formal Validation (2025)**
+
+- **Benchmarking Study**: Formally test TOE techniques against standard benchmarks
+- **Quantitative Analysis**: Replace informal observations with data
+- **Methodology**: Proper experimental design, controls, statistical analysis
+- **Peer Review**: Submit findings for review if results are significant
+- **Collaboration**: Work with academic researchers for credibility
+
+### **Potential Novel Research Areas**
+
+If my work uncovers genuinely novel insights:
+- **Domain-Specific Patterns**: Unique patterns for PropTech/Real Estate AI
+- **Production System Learnings**: Insights from large-scale deployment
+- **Failure Analysis**: Systematic study of what doesn't work and why
+- **Tool Development**: Novel tools for automated prompt optimization
+
+### **Honest Timeline**
+
+- **2025 Q2**: Complete formal benchmarking with proper methodology
+- **2025 Q3**: Analysis and write-up
+- **2025 Q4**: Submit for review (if results warrant publication)
+- **2026+**: Potential PhD if research direction proves promising
+
+**I'm not there yet. But this is the path from "builder who documents" to "builder who researches."**
+```
+
+**Lines 860-871:** Current:
+```markdown
+## Conclusion
+
+This research demonstrates that **AI verification is not just possible, but essential** for production use...
+
+The research shows that **AI can be made reliable and trustworthy**...
+
+**Research Team**: Friday Unified Development Team  
+**Date**: January 2025  
+```
+
+**Change to:**
+```markdown
+## Conclusion
+
+This framework demonstrates that **AI verification is achievable** through systematic approaches:
+
+1. **Honesty is Engineerable**: Prompt engineering can encourage AI to be more honest about capabilities
+2. **Testing is Essential**: Benchmarking proves code works in real scenarios
+3. **Context Management Works**: Memory systems enable work on large codebases
+4. **Integration Matters**: Systems work better together
+
+**What This Proves:**
+Through practical application in production systems, these techniques improve AI reliability and trustworthiness.
+
+**What This Doesn't Prove:**
+Without formal research, I can't make quantitative claims or scientific conclusions. This is practitioner knowledge, not peer-reviewed science.
+
+**What I Hope:**
+This framework saves you time and provides a starting point for your work. If you build on this, please share your findings.
+
+---
+
+**Framework Developer**: David Edwards, Pineapple Lab  
+**Date**: January 2025  
+**License**: Apache-2.0 (Open Source)  
+**Status**: Practitioner Framework (Not Peer-Reviewed Research)
+```
+
+---
+
+### 3. XML_Tag_Structuring_Guide.md (MINOR UPDATES)
+
+**Good News:** This document already has decent attribution to Anthropic. Just need minor consistency updates.
+
+**Line 8:** Current is already good, just add:
+```markdown
+**Attribution:** This technique is extensively documented by Anthropic and is a core recommendation in their official prompt engineering guide. This guide provides my practical implementation examples and lessons learned.
+```
+
+---
+
+### 4. Advanced_Logic_Building_Guide.md (MINOR UPDATES)
+
+**Lines 18-20:** Current is good, just ensure consistency:
+```markdown
+**Research Foundation**: Introduced by Wei et al. (2022) in their groundbreaking paper *"Chain-of-thought prompting elicits reasoning in large language models"* (19,810+ citations), CoT prompting has been shown to significantly improve performance on arithmetic, commonsense, and symbolic reasoning tasks.
+
+**My Contribution**: I've extensively applied their research to production AI agent development, documenting specific patterns and examples that work well in my domain (PropTech, AI systems). This guide provides implementation examples and practical lessons learned from real-world use.
+```
+
+---
+
+### 5. Prompt_Engineering_Blueprint.md (MINOR UPDATES)
+
+**Lines 11-23:** Current:
+```markdown
+## 🔗 Purpose of This Guide
+
+This guide is part of an evolving set of findings from Pineapple Labs...
+
+The idea behind publishing this is to open-source the design patterns, techniques, and structures I've found useful...
+
+**This Blueprint is the master methodology** that integrates all Pineapple Lab techniques:
+```
+
+**Add before the bullet list:**
+```markdown
+**Important Context**: This blueprint integrates techniques from multiple sources (Anthropic, Google, OpenAI, academic research) into one cohesive framework. I didn't invent these individual techniques — I've organized them into a systematic approach that works for me.
+
+**This Blueprint integrates:**
+```
+
+---
+
+### 6. Starting_Guide_for_Newbies_Prompt_Engineering.md (MINIMAL UPDATES)
+
+**Line 469:** Current:
+```markdown
+*Part of the Pineapple Lab OS Docs - Open Research & Publications*
+```
+
+**Change to:**
+```markdown
+*Part of the Pineapple Lab OS Docs - Practitioner's Guide Series*
+```
+
+---
+
+## 🎯 Key Messaging Throughout All Documents
+
+### Replace These Phrases:
+
+| ❌ Remove/Replace | ✅ Use Instead |
+|-------------------|----------------|
+| "breakthrough methodology" | "systematic framework" or "organized approach" |
+| "novel approach" | "practical application" or "synthesis of techniques" |
+| "research-backed" (implying your research) | "based on research by [authors]" |
+| "significant advances in the field" | "practical improvements in my work" |
+| "Research Team" | "Framework Developer" or "Author" |
+| "This research demonstrates" | "My experience shows" or "In practice, I've found" |
+| "Research Overview" | "Framework Overview" or "Practical Approach" |
+| "Research Results" | "Observed Outcomes (Informal)" |
+| Specific percentages without data | "Substantial improvement" or "Significant reduction" |
+| "We believe" / "We demonstrate" | "I've observed" / "In my experience" |
+
+---
+
+## 📊 Priority Order for Changes
+
+### **Phase 1: Critical (Do First)**
+1. ✅ README.md - Main positioning (most visible)
+2. ✅ TOE Document - Remove quantitative claims
+3. ✅ Add "About This Project" section to README
+4. ✅ Add "My Actual Contributions" section
+
+### **Phase 2: Important (Do Second)**
+5. ✅ Update Blueprint with clearer positioning
+6. ✅ Ensure XML and Logic guides have consistent attribution
+7. ✅ Add Roadmap section showing journey to potential research
+
+### **Phase 3: Polish (Do Third)**
+8. ✅ Update Starting Guide (minimal changes needed)
+9. ✅ Comprehensive credits/references section
+10. ✅ Consistent terminology throughout all documents
+
+---
+
+## ✅ Validation Checklist
+
+After making changes, verify:
+
+- [ ] No claims of "breakthrough" or "novel" research
+- [ ] All quantitative claims either removed or heavily caveated
+- [ ] Clear attribution for Chain-of-Thought (Wei et al., Kojima et al.)
+- [ ] Clear attribution for XML tags (Anthropic)
+- [ ] "About David" section explains role as synthesizer
+- [ ] "My Actual Contributions" clearly separates learned vs created
+- [ ] Roadmap shows honest journey (currently synthesis, future potential research)
+- [ ] Consistent use of "framework" not "research"
+- [ ] All informal observations labeled as such
+- [ ] References properly cited throughout
+- [ ] Honest positioning: "practitioner's guide" not "research lab"
+
+---
+
+## 🎓 The New Elevator Pitch
+
+**Old (Problematic):**
+"Pineapple Lab OS Docs is a breakthrough research project advancing the state of the art in prompt engineering."
+
+**New (Honest):**
+"Pineapple Lab OS Docs is a practitioner's guide where I've compiled and organized prompt engineering techniques from Anthropic, Google, OpenAI, and academic research. I've tested these extensively while building AI products and created practical examples and frameworks. It's not research — it's synthesis, organization, and application guidance. I'm standing on the shoulders of giants and documenting the climb."
+
+---
+
+## 🚀 Why This Repositioning Matters
+
+### **Credibility**
+- Researchers will respect honesty
+- Practitioners will trust authenticity
+- Employers/investors will see clear thinking
+
+### **Long-term Career**
+- Build reputation on truth, not hype
+- Foundation for potential future research
+- Honest positioning today → credible voice tomorrow
+
+### **Competitive Advantage**
+- Everyone else is claiming breakthroughs
+- You're the honest voice in a hype-filled space
+- Authenticity is your moat
+
+### **Sleep Well at Night**
+- No fear of being exposed
+- No fake claims to defend
+- Just good work, honestly positioned
+
+---
+
+## 📝 Commit Message for Changes
+
+```
+feat: Reposition from "research" to "practitioner's synthesis"
+
+BREAKING CHANGE: Major repositioning of project claims
+
+- Remove "breakthrough" and "novel research" claims
+- Add clear attribution for all source material
+- Remove unsubstantiated quantitative metrics (85%, 95%)
+- Add "About This Project" section with honest context
+- Add "My Actual Contributions" section
+- Reframe TOE from "research" to "framework"
+- Add roadmap showing journey from documentation to potential research
+- Update all terminology from "research" to "framework/guide"
+
+This repositioning reflects accurate representation of the work:
+synthesis and practical application of techniques from Anthropic,
+Google, OpenAI, and academic researchers (Wei, Kojima, et al.)
+
+Standing on the shoulders of giants, documenting the climb.
+```
+
+---
+
+## 🎤 The Elon Musk Final Word
+
+"Stop bullshitting. You did good work. Own what you actually did. 
+
+You're a builder who reads a lot, tests things, and documents what works. That's valuable. That's honest. That's sustainable.
+
+Fake breakthroughs get exposed. Honest documentation compounds.
+
+Make these changes. Sleep well. Build great things."
+
+---
+
+**End of Action Plan**
+
+**Next Step:** Start with README.md Phase 1 changes, then move systematically through each file.
+
+**Timeline:** With focused work, all changes can be completed in 4-6 hours.
+
+**Impact:** Transform credibility from questionable to authentic, immediately.
+
+

--- a/Starting_Guide_for_Newbies_Prompt_Engineering.md
+++ b/Starting_Guide_for_Newbies_Prompt_Engineering.md
@@ -466,5 +466,5 @@ Welcome to prompt engineering. Now go build something amazing.
 
 ---
 
-*Part of the Pineapple Lab OS Docs - Open Research & Publications*
+*Part of the Pineapple Lab OS Docs - Practitioner's Guide Series*
 


### PR DESCRIPTION
BREAKING CHANGE: Major repositioning of project claims and positioning

Changes:
- README.md: Complete overhaul with honest positioning
  - Changed from 'definitive resource' to 'practitioner's guide'
  - Added 'What This IS and IS NOT' section
  - Added 'My Actual Contributions' section clearly separating learned techniques from original work
  - Added 'Roadmap: From Documentation to Research' showing honest journey
  - Removed all 'breakthrough' and 'research lab' claims
  - Added proper attribution throughout (Wei et al., Kojima et al., Anthropic, Google, OpenAI)
  - Updated version to 2.1

- Pineapple_Lab_TOE_Context_Engineering_for_Agents.md: Framework repositioning
  - Changed title to 'A Practitioner's Framework for AI Honesty and Reliability'
  - Removed ALL quantitative claims (85%, 95%, 70%, 60%, 90%, 80%) without formal testing
  - Replaced with honest observations: 'What I've Observed' and 'My Experience'
  - Added caveats about informal observations vs. formal research
  - Changed 'Research Contributions' to 'My Contributions to the Community'
  - Added 'Future Development Plans' with honest timeline for formal validation

- Prompt Engineering Blue Print.md: Clarified integration vs. invention
  - Added context about synthesizing techniques from multiple sources
  - Clear attribution: TOE (my synthesis), XML (Anthropic), CoT (Wei et al./Kojima et al.)

- Starting_Guide_for_Newbies_Prompt_Engineering.md: Updated footer
  - Changed from 'Open Research & Publications' to 'Practitioner's Guide Series'

- Contribution Guide.md: Authentic voice update
  - Changed from 'research-driven space' to 'open learning space'
  - Updated signature from 'Pineapple Labs' to 'David Edwards / Pineapple Lab'

Impact:
This repositioning reflects accurate representation of the work: synthesis and practical application of techniques from Anthropic, Google, OpenAI, and academic researchers (Wei, Kojima, et al.)

Standing on the shoulders of giants, documenting the climb.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Repositioned the project from “research” to a concise, honest “practitioner’s guide,” removing unvalidated claims and adding clear attribution and context across the docs. This improves credibility, clarifies scope, and updates the framework to reflect synthesis and practical application.

- **Refactors**
  - README: Overhauled positioning, removed “breakthrough/research lab” language, added proper attribution, updated to v2.1.
  - TOE document: Retitled and rewritten with observations and caveats; removed all quantitative claims; renamed contributions; added validation timeline.
  - Blueprint: Clarified synthesis vs. invention with citations (Anthropic, Wei/Kojima).
  - Contribution Guide: Updated tone to “open learning space” and signature to “David Edwards / Pineapple Lab”.
  - Starting Guide: Footer changed to “Practitioner’s Guide Series”.

- **New Features**
  - README: Added “What This IS and IS NOT,” “My Actual Contributions,” and “Roadmap: From Documentation to Research.”
  - Added REPOSITIONING_ACTION_PLAN.md outlining the shift and action steps.

<!-- End of auto-generated description by cubic. -->

